### PR TITLE
Fixes Ryot Authentication Issue

### DIFF
--- a/templates/ryot.xml
+++ b/templates/ryot.xml
@@ -21,7 +21,7 @@
   <Requires>
   Depends on: PostgreSQL 15
   </Requires>
-  <Config Name="Server Insecure Cookie" Target="SERVER_INSECURE_COOKIE" Default="true" Mode="" Description="" Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Frontend Insecure Cookie" Target="FRONTEND_INSECURE_COOKIES" Default="true" Mode="" Description="" Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="Postgres DB URL" Target="DATABASE_URL" Default="postgres://postgres:postgres@postgres:5432/postgres" Mode="" Description="" Type="Variable" Display="always" Required="true" Mask="false"/>
   <Config Name="Web UI" Target="8000" Default="8000" Mode="tcp" Description="" Type="Port" Display="always" Required="true" Mask="false"></Config>
   <Config Name="Data Dir" Target="/data" Default="/mnt/user/appdata/ryot" Mode="rw" Description="" Type="Path" Display="advanced" Required="true" Mask="false"></Config>


### PR DESCRIPTION
To allow non-HTTPS connections, you we're required to put "SERVER_INSECURE_COOKIE = true", as per the documentation it appears this variable was renamed to "FRONTEND_INSECURE_COOKIES" which means logging in isn't possible as the templates target doesn't exist.

TLDR:
Devs renamed a config variable that's important to logging in, this fixes it.

Source:
(https://ignisda.github.io/ryot/configuration.html)
![image](https://github.com/Homelabbers/unraid-templates/assets/32248891/5dc60cac-fb0f-42b8-b13d-7b8189f7caef)
